### PR TITLE
Update FileTransport to support running in any directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # apama-streaming-analytics-connectivity-FileTransport
-Java based Connectivity Transport for reading/writing to files for use with [Apama](https://www.apamacommunity.com/).
+Java-based connectivity transport plug-in for reading/writing to files for use with [Apama](https://www.apamacommunity.com/).
 
 ## Description
-File Transport Connectivity Plugin. Will operate on files line by line, either sending each line as a message towards the host or writing each message sent towards the transport. For more information on the Apama Connectivity Framework, as well as Apama in general, please see [the community website](https://www.apamacommunity.com/).
+File Transport Connectivity Plug-in. Will operate on files line by line, either sending each line as a message towards the host or writing each message sent towards the transport. For more information on the Apama Connectivity Framework, as well as Apama in general, please see [the community website](https://www.apamacommunity.com/).
 
 ## Set-up
 First, ensure you have an install of the Apama engine; a free edition is available at [the community website](https://www.apamacommunity.com/). This plugin assumes the user has familiarity with the basic structure of the install, more information of which can also be found on the community site.
@@ -35,12 +35,11 @@ A successful build will produce output files for the File Transport:
 These should have already been copied to APAMA_WORK/lib where the correlator will load them from.
 
 # Authors
-[Callum Attryde](mailto:Callum.Attryde@softwareag.com)
-
-[John Heath](mailto:John.Heath@softwareag.com)
+Callum Attryde
+John Heath
 
 ## License
-Copyright (c) 2017-2019 Software AG, Darmstadt, Germany and/or its licensors
+Copyright (c) 2017-2019, 2021 Software AG, Darmstadt, Germany and/or its licensors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 file except in compliance with the License. You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # apama-streaming-analytics-connectivity-FileTransport
-Java based Connectivity Transport for reading/writing to files for use with [Apama](http://www.apamacommunity.com/).
+Java based Connectivity Transport for reading/writing to files for use with [Apama](https://www.apamacommunity.com/).
 
 ## Description
-File Transport Connectivity Plugin. Will operate on files line by line, either sending each line as a message towards the host or writing each message sent towards the transport. For more information on the Apama Connectivity Framework, as well as Apama in general, please see [the community website](http://www.apamacommunity.com/).
+File Transport Connectivity Plugin. Will operate on files line by line, either sending each line as a message towards the host or writing each message sent towards the transport. For more information on the Apama Connectivity Framework, as well as Apama in general, please see [the community website](https://www.apamacommunity.com/).
 
 ## Set-up
-First, ensure you have an install of the Apama engine; a free edition is available at [the community website](http://www.apamacommunity.com/). This plugin assumes the user has familiarity with the basic structure of the install, more information of which can also be found on the community site.
+First, ensure you have an install of the Apama engine; a free edition is available at [the community website](https://www.apamacommunity.com/). This plugin assumes the user has familiarity with the basic structure of the install, more information of which can also be found on the community site.
 
 Running and building of the sample requires access to the Correlator and Apama command line tools. To ensure that the environment is configured correctly for Apama, all the commands below should be executed from an Apama Command Prompt, or from a shell or command prompt where the bin\apama_env script has been run (or sourced on Unix).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Java-based connectivity transport plug-in for reading/writing to files for use w
 File Transport Connectivity Plug-in. Will operate on files line by line, either sending each line as a message towards the host or writing each message sent towards the transport. For more information on the Apama Connectivity Framework, as well as Apama in general, please see [the community website](https://www.apamacommunity.com/).
 
 ## Set-up
-First, ensure you have an install of the Apama engine; a free edition is available at [the community website](https://www.apamacommunity.com/). This plugin assumes the user has familiarity with the basic structure of the install, more information of which can also be found on the community site.
+First, ensure you have an install of the Apama product; a free edition is available at [the community website](https://www.apamacommunity.com/). This plugin assumes the user has familiarity with the basic structure of the install, more information of which can also be found on the community site.
 
 Running and building of the sample requires access to the Correlator and Apama command line tools. To ensure that the environment is configured correctly for Apama, all the commands below should be executed from an Apama Command Prompt, or from a shell or command prompt where the bin\apama_env script has been run (or sourced on Unix).
 

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	Copyright © 2017 Software AG, Darmstadt, Germany and/or its licensors
+	Copyright © 2017, 2021 Software AG, Darmstadt, Germany and/or its licensors
   
 	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
   
@@ -8,7 +8,7 @@
   
 	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 	-->
-<project default="file-transport-copy" name="File Transport Connectivity plugin">
+<project default="file-transport-copy" name="FileTransport">
 
 	<presetdef name="javac">
 		<javac includeantruntime="false" />
@@ -18,7 +18,7 @@
 	<property name="APAMA_HOME" location="${env.APAMA_HOME}"/>
 	<fail unless="env.APAMA_HOME" message="Please run the bin/apama_env script before attempting to build this sample."/>
 
-	<property name="file-transport-source-dir" location="../FileTransport"/>
+	<dirname property="file-transport-source-dir" file="${ant.file.FileTransport}"/>
 	<property name="file-transport-output-dir" location="${file-transport-source-dir}/build-output"/>
 	<property name="file-transport-output-jar" location="${file-transport-output-dir}/file-transport-plugins.jar"/>
 


### PR DESCRIPTION
Updates this sample to support running in any directory name, without breaking compatibility with RegEx sample. 

Resolves #5. 